### PR TITLE
drfileitem: Avoid ambiguous cast

### DIFF
--- a/drfileitem.h
+++ b/drfileitem.h
@@ -89,7 +89,7 @@ private:
     QString path;
     QString name;
     QDateTime creationTime;
-    uint64_t dataSize;
+    qulonglong dataSize;
     DRFileType type;
 };
 


### PR DESCRIPTION
The build fails with Qt 5.2.1 without this fix due to the following
error.

"""
drfileitem.cpp: In member function ‘QVariant DRFileItem::data(int) const’:
drfileitem.cpp:96:22: error: conversion from ‘const uint64_t {aka const long unsigned int}’ to ‘QVariant’ is ambiguous
         return this->dataSize;
                      ^
drfileitem.cpp:96:22: note: candidates are:
In file included from /usr/include/qt5/QtCore/qlocale.h:45:0,
                 from /usr/include/qt5/QtCore/qtextstream.h:48,
                 from /usr/include/qt5/QtCore/qdebug.h:50,
                 from /usr/include/qt5/QtCore/QDebug:1,
                 from drfileitem.cpp:20:
/usr/include/qt5/QtCore/qvariant.h:483:5: note: QVariant::QVariant(Qt::CursorShape) <near match>
     QVariant(Qt::CursorShape) Q_DECL_EQ_DELETE;
     ^
/usr/include/qt5/QtCore/qvariant.h:483:5: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘Qt::CursorShape’
/usr/include/qt5/QtCore/qvariant.h:482:5: note: QVariant::QVariant(Qt::PenStyle) <near match>
     QVariant(Qt::PenStyle) Q_DECL_EQ_DELETE;
     ^
/usr/include/qt5/QtCore/qvariant.h:482:5: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘Qt::PenStyle’
/usr/include/qt5/QtCore/qvariant.h:481:5: note: QVariant::QVariant(Qt::BrushStyle) <near match>
     QVariant(Qt::BrushStyle) Q_DECL_EQ_DELETE;
     ^
/usr/include/qt5/QtCore/qvariant.h:481:5: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘Qt::BrushStyle’
/usr/include/qt5/QtCore/qvariant.h:480:5: note: QVariant::QVariant(Qt::GlobalColor) <near match>
     QVariant(Qt::GlobalColor) Q_DECL_EQ_DELETE;
     ^
/usr/include/qt5/QtCore/qvariant.h:480:5: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘Qt::GlobalColor’
/usr/include/qt5/QtCore/qvariant.h:473:5: note: QVariant::QVariant(QMetaType::Type) <near match>
     QVariant(QMetaType::Type) Q_DECL_EQ_DELETE;
     ^
/usr/include/qt5/QtCore/qvariant.h:473:5: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘QMetaType::Type’
/usr/include/qt5/QtCore/qvariant.h:466:12: note: QVariant::QVariant(void_) <near match>
     inline QVariant(void *) Q_DECL_EQ_DELETE;
            ^
/usr/include/qt5/QtCore/qvariant.h:466:12: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘void_’
/usr/include/qt5/QtCore/qvariant.h:216:24: note: QVariant::QVariant(const char_) <near match>
     QT_ASCII_CAST_WARN QVariant(const char *str);
                        ^
/usr/include/qt5/QtCore/qvariant.h:216:24: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘const char_’
/usr/include/qt5/QtCore/qvariant.h:214:5: note: QVariant::QVariant(float)
     QVariant(float f);
     ^
/usr/include/qt5/QtCore/qvariant.h:213:5: note: QVariant::QVariant(double)
     QVariant(double d);
     ^
/usr/include/qt5/QtCore/qvariant.h:212:5: note: QVariant::QVariant(bool)
     QVariant(bool b);
     ^
/usr/include/qt5/QtCore/qvariant.h:211:5: note: QVariant::QVariant(qulonglong)
     QVariant(qulonglong ull);
     ^
/usr/include/qt5/QtCore/qvariant.h:210:5: note: QVariant::QVariant(qlonglong)
     QVariant(qlonglong ll);
     ^
/usr/include/qt5/QtCore/qvariant.h:209:5: note: QVariant::QVariant(uint)
     QVariant(uint ui);
     ^
/usr/include/qt5/QtCore/qvariant.h:208:5: note: QVariant::QVariant(int)
     QVariant(int i);
     ^
/usr/include/qt5/QtCore/qvariant.h:199:5: note: QVariant::QVariant(QVariant::Type) <near match>
     QVariant(Type type);
     ^
/usr/include/qt5/QtCore/qvariant.h:199:5: note:   no known conversion for argument 1 from ‘const uint64_t {aka const long unsigned int}’ to ‘QVariant::Type’
"""

We can avoid the ambiguous cast by using a filetype that QtVariant has a
constructor or cast operator for, like qulonglong. This commit replaces
our use of uint64_t for DRFileItem::dataSize with qulonglong.
